### PR TITLE
Do not print EADDRINUSE errors in rtmp proto, since it's intentional …

### DIFF
--- a/libavformat/rtmpproto.c
+++ b/libavformat/rtmpproto.c
@@ -2676,7 +2676,9 @@ reconnect:
     if ((ret = ffurl_open_whitelist(&rt->stream, buf, AVIO_FLAG_READ_WRITE,
                                     &s->interrupt_callback, opts,
                                     s->protocol_whitelist, s->protocol_blacklist, s)) < 0) {
-        av_log(s , AV_LOG_ERROR, "Cannot open connection %s\n", buf);
+        if (ret != -EADDRINUSE) {
+            av_log(s , AV_LOG_ERROR, "Cannot open connection %s\n", buf);
+        }
         goto fail;
     }
 


### PR DESCRIPTION
…for proxy