### PR TITLE
Cast availability time offset to double before converting to seconds …

### DIFF
--- a/libavformat/dashenc.c
+++ b/libavformat/dashenc.c
@@ -2434,7 +2434,7 @@ static int dash_write_packet(AVFormatContext *s, AVPacket *pkt)
 
          os->availability_time_offset = availability_time_offset == -1 ?
                                         ((double) os->seg_duration - frame_duration) / AV_TIME_BASE :
-                                        US_TO_S(availability_time_offset);
+                                        US_TO_S((double)availability_time_offset);
         as->max_frag_duration = FFMAX(frame_duration, as->max_frag_duration);
     }
 


### PR DESCRIPTION
…to allow fractional values